### PR TITLE
remove unused var in function selectionSort()

### DIFF
--- a/Chapter12/Chap12-6.js
+++ b/Chapter12/Chap12-6.js
@@ -1,13 +1,11 @@
+
 function selectionSort() {
-   var min, temp;
    for (var outer = 0; outer <= this.dataStore.length-2; ++outer) {
-      min = outer;
       for (var inner = outer + 1; 
            inner <= this.dataStore.length-1; ++inner) {         
-         if (this.dataStore[inner] < this.dataStore[min]) {
-            min = inner;  
+         if (this.dataStore[inner] < this.dataStore[outer]) {
+            swap(this.dataStore, inner, outer);
          }
       }
-      swap(this.dataStore, outer, min);
    }
 }  


### PR DESCRIPTION
selectionSort()

Original code example has an unused var temp. We can drop that var.

``` js
function selectionSort() {
   var min;
   for (var outer = 0; outer <= this.dataStore.length-2; ++outer) {
      min = outer;
      for (var inner = outer + 1; 
           inner <= this.dataStore.length-1; ++inner) {         
         if (this.dataStore[inner] < this.dataStore[min]) {
            min = inner;  
         }
      }
      swap(this.dataStore, outer, min);
   }
}  
```

We can drop the var min by moving swap into the if clause in inner for loop.  I think this is better because otherwise even if outer and min is the same value, swap is called.  It's a bit confusing.

``` js

function selectionSort() {
   for (var outer = 0; outer <= this.dataStore.length-2; ++outer) {
      for (var inner = outer + 1; 
           inner <= this.dataStore.length-1; ++inner) {         
         if (this.dataStore[inner] < this.dataStore[outer]) {
            swap(this.dataStore, inner, outer);
         }
      }
   }
}  

```
